### PR TITLE
RBedTool, context managers, and verbose error messages

### DIFF
--- a/dnaset/__init__.py
+++ b/dnaset/__init__.py
@@ -1,5 +1,14 @@
 import dnaset.bed_dataset
 import dnaset.bigwig_dataset
+bigwig_dataset = dnaset.bigwig_dataset
+bed_dataset = dnaset.bed_dataset
+
+
 
 #dnaset.util package is referenced by bigwig_dataset as "util"
-import dnaset.util as util
+import dnaset.util
+util = dnaset.util
+
+import dnaset.rbedtool
+rbedtool = dnaset.rbedtool
+

--- a/dnaset/bigwig_dataset.py
+++ b/dnaset/bigwig_dataset.py
@@ -9,10 +9,8 @@ import random
 
 from typing import Union, List, Optional, Callable
 
-import dnaset.util as util
-from dnaset.rbedtool import RBedTool
-import math
-import sys
+import util
+from rbedtool import RBedTool
 
 
 CATCH_GENERATOR_INDEX_ERROR = False

--- a/dnaset/bigwig_dataset.py
+++ b/dnaset/bigwig_dataset.py
@@ -187,7 +187,9 @@ def bigwig_dataset_generator(
         start = interval.start
         stop = interval.stop
         # we copy to make the resulting array mutable
-        
+        if chrom is None: #handles parse error in rbedtool
+            continue
+
         try:
             cause = "Fasta"
             sequence = sequence_transform(reference_fasta[chrom][start:stop])

--- a/dnaset/bigwig_dataset.py
+++ b/dnaset/bigwig_dataset.py
@@ -9,8 +9,8 @@ import random
 
 from typing import Union, List, Optional, Callable
 
-import util
-from rbedtool import RBedTool
+from dnaset import util
+from dnaset.rbedtool import RBedTool
 
 
 CATCH_GENERATOR_INDEX_ERROR = False

--- a/dnaset/bigwig_dataset.py
+++ b/dnaset/bigwig_dataset.py
@@ -207,8 +207,10 @@ def bigwig_dataset_generator(
                     'sequence': sequence,
                     'values': values
                     }
-        else:
+        elif out_type == 'tuple':
             yield sequence, values
+        else:
+            raise ValueError(f"out type must be 'tuple' or 'int' (got {out_type})")
 
 class catch_generator_index_error():
     '''

--- a/dnaset/bigwig_dataset.py
+++ b/dnaset/bigwig_dataset.py
@@ -177,10 +177,11 @@ def bigwig_dataset_generator(
         return gen
 
     def index_error_handler(msg):
-            if CATCH_GENERATOR_INDEX_ERROR:
-                print(msg)
-                return None
-            raise IndexError(msg)
+        global CATCH_GENERATOR_INDEX_ERROR
+        if CATCH_GENERATOR_INDEX_ERROR:
+            print(msg)
+            return None
+        raise IndexError(msg)
 
     for interval in sequence_bed.slice(start,stop):
         chrom = interval.chrom
@@ -213,9 +214,11 @@ class catch_generator_index_error():
     and printed to stderr
     '''
     def __enter__(self):
-        CATCH_OUT_OF_RANGE_GENERATOR=True
+        global CATCH_GENERATOR_INDEX_ERROR
+        CATCH_GENERATOR_INDEX_ERROR=True
     def __exit__(self, *args):
-        CATCH_OUT_OF_RANGE_GENERATOR=False
+        global CATCH_GENERATOR_INDEX_ERROR
+        CATCH_GENERATOR_INDEX_ERROR=True
 
 
 
@@ -326,3 +329,4 @@ class BigWigDataset(IterableDataset):
                     iter_start,
                     iter_end,
                 )
+

--- a/dnaset/bigwig_dataset.py
+++ b/dnaset/bigwig_dataset.py
@@ -10,7 +10,7 @@ import random
 from typing import Union, List, Optional, Callable
 
 import dnaset.util as util
-from rbedtool import RBedTool
+from dnaset.rbedtool import RBedTool
 import math
 import sys
 

--- a/dnaset/bigwig_dataset.py
+++ b/dnaset/bigwig_dataset.py
@@ -157,6 +157,7 @@ def bigwig_dataset_generator(
             Note that it will take O(start) time to yield the first value!
         stop: which row of the bed file to  end at (negative numbers index from the end of the file, just
             like regular array slicing)
+	out_type: the output type. Can be 'dict' or 'tuple'
     '''
 
     bigwig_files = convert_single_to_list(bigwig_files, str)
@@ -288,12 +289,6 @@ class BigWigDataset(IterableDataset):
         self.out_type = out_type
 
     def __len__(self):
-        # TODO: pybedtools is embarassingly slow at calculating lengths,
-        # so we defer calculuation until needed. In future, we may need
-        # to find a replacement for pybedtools that is not so slow.
-        # For example, even a pure python implementation is faster even though
-        # pybedtools is using cython to parse the lines of the bed file...
-
         # rbedtools will compute the length of the file in lines at initialization 
         return len(self.input_bed)
 

--- a/dnaset/bigwig_dataset.py
+++ b/dnaset/bigwig_dataset.py
@@ -195,9 +195,10 @@ def bigwig_dataset_generator(
             cause = "Bigwig"
             values = [bw.values(chrom, start, stop, numpy=True) for bw in bigwigs]
         except (IndexError):
-            return index_error_handler(
+            index_error_handler(
                 f"Base pairs {start} to {stop} in chrom {chrom} are not accessible in {cause} file"
             )
+            continue
         
         yield {
                 'sequence': sequence,

--- a/dnaset/rbedtool.py
+++ b/dnaset/rbedtool.py
@@ -1,6 +1,3 @@
-import csv
-from randomAccessReader import CsvRandomAccessReader
-
 class BedLine():
 	def __init__(self,s):
 		s = s.split('\t')
@@ -38,7 +35,7 @@ class RBedTool():
 			fp.seek(fp.tell()-j)
 		
 		line_align(fp)
-		
+
 		for _ in range(idx-self.line):
 			fp.readline()
 		self.line = idx+1

--- a/dnaset/rbedtool.py
+++ b/dnaset/rbedtool.py
@@ -15,10 +15,10 @@ class BedFrame():
 			s = f"There was an issue while trying to parse BedFrame input\nline {current_line}: {s}"
 			if CATCH_BED_PARSE_ERROR:
 				print(s)
-				self = None
+				self.chrom = None
 			else:
 				raise ValueError(s)
-				
+
 class RBedTool():
 	'''
 	A simple class for iterating over the lines of a bed file.

--- a/dnaset/rbedtool.py
+++ b/dnaset/rbedtool.py
@@ -15,6 +15,7 @@ class BedFrame():
 			s = f"There was an issue while trying to parse BedFrame input\nline {current_line}: {s}"
 			if CATCH_BED_PARSE_ERROR:
 				print(s)
+				print("catch_bed_parser_error is enabled. self.chrom will be None")
 				self.chrom = None
 			else:
 				raise ValueError(s)

--- a/dnaset/rbedtool.py
+++ b/dnaset/rbedtool.py
@@ -1,15 +1,24 @@
 from itertools import islice
 
-class BedLine():
+class BedFrame():
 	def __init__(self,s):
-		s = s.split('\t')
-		self.chrom = s[0]
-		self.start = int(s[1])
-		self.stop = int(s[2])
+		try:
+			a = s.split('\t')
+			self.chrom = a[0]
+			self.start = int(a[1])
+			self.stop = int(a[2])
+		except:
+			raise ValueError(f"There was an issue while trying to parse BedFrame input ('{s}')")
 		
 class RBedTool():
 	'''
-	A simple class for iterating over a .bed file
+	A simple class for iterating over the lines of a bed file.
+	Accessing elements sequentially (such as with an iterator) is
+	O(1). Otherwise, the BedTool will perform a linear search
+	for the accessed line.
+
+	__getitem__() will return a BedFrame object, a simple struct with
+	feilds chrom, stop, and start
 	'''
 	def __init__(self,pth):
 		'''
@@ -48,7 +57,7 @@ class RBedTool():
 		for _ in range(idx-self.line):
 			fp.readline()
 		self.line = idx+1
-		return BedLine(fp.readline())
+		return BedFrame(fp.readline())
 
 	def __iter__(self):
 		return RBedToolIterator(self)

--- a/dnaset/rbedtool.py
+++ b/dnaset/rbedtool.py
@@ -1,5 +1,3 @@
-from itertools import islice
-
 CATCH_BED_PARSE_ERROR = False
 current_line = 0
 
@@ -18,6 +16,8 @@ class BedFrame():
 				print(s)
 				print("catch_bed_parser_error is enabled. self.chrom will be None")
 				self.chrom = None
+				self.start = None
+				self.stop = None
 			else:
 				raise ValueError(s)
 

--- a/dnaset/rbedtool.py
+++ b/dnaset/rbedtool.py
@@ -1,0 +1,77 @@
+import csv
+from randomAccessReader import CsvRandomAccessReader
+
+class BedLine():
+	def __init__(self,s):
+		s = s.split('\t')
+		self.chrom = s[0]
+		self.start = int(s[1])
+		self.stop = int(s[2])
+		
+class RBedTool():
+	'''
+	A simple class for iterating over a .bed file
+	'''
+	def __init__(self,pth):
+		#this is relatively fast, according to stack overflow
+		with open(pth, "rbU") as f:
+			self.sz = sum(1 for _ in f)
+		
+		self.fp = open(pth)
+		self.line = 0
+
+	def __getitem__(self,idx):
+		def line_align(fp):
+			#backs up a file pointer character-by-character until it reaches a newline
+			while fp.tell()!=0 and fp.read(1)!='\n':
+				fp.seek(fp.tell()-2)
+		
+		if idx >= len(self):
+			raise IndexError
+		j = 64
+		fp = self.fp
+		while self.line > idx and self.line!=0:
+			while fp.tell() < j-1 and j > 1:
+				j = j//2
+			fp.seek(fp.tell()-j)
+			self.line -= fp.read(j).count('\n')
+			fp.seek(fp.tell()-j)
+		
+		line_align(fp)
+		
+		for _ in range(idx-self.line):
+			fp.readline()
+		self.line = idx+1
+		return BedLine(fp.readline())
+
+	def __iter__(self):
+		return RBedToolIterator(self)
+
+	def __len__(self):
+		return self.sz
+
+class RBedToolIterator:
+	'''
+	This is added so that multiple RBedToolIterators of the same RBedTool will not interfere with each other
+	'''
+	def __init__(self,rbedtool):
+		self.rbedtool = rbedtool
+		self.pos = 0
+		self.it = 0
+
+	def __next__(self):
+
+		if self.it == len(self.rbedtool):
+			raise StopIteration
+		self.rbedtool.fp.seek(self.pos)
+		self.rbedtool.line = self.it
+
+		ret = self.rbedtool[self.it]
+
+		self.pos = self.rbedtool.fp.tell()
+		self.it+=1
+		return ret
+
+    
+
+	

--- a/dnaset/rbedtool.py
+++ b/dnaset/rbedtool.py
@@ -6,6 +6,7 @@ current_line = 0
 class BedFrame():
 	def __init__(self,s):
 		global current_line
+		global CATCH_BED_PARSE_ERROR
 		try:
 			a = s.split('\t')
 			self.chrom = a[0]
@@ -156,7 +157,9 @@ class RBedToolIterator:
 
 	
 class catch_bed_parse_error():
-	def __enter__():
+	def __enter__(self):
+		global CATCH_BED_PARSE_ERROR
 		CATCH_BED_PARSE_ERROR = True
-	def __exit__():
+	def __exit__(self,*args):
+		global CATCH_BED_PARSE_ERROR
 		CATCH_BED_PARSE_ERROR = False

--- a/dnaset/util.py
+++ b/dnaset/util.py
@@ -1,10 +1,17 @@
 import numpy as np
+import torch
 
 from pybedtools import BedTool
 from pyfaidx import Fasta
 
 def seq_to_array(s, copy=True):
     array = np.asarray(memoryview(str(s).encode('ascii')), dtype=np.uint8)
+    if copy:
+        array = array.copy()
+    return array
+
+def seq_to_torch(s, copy=True):
+    array = torch.Tensor(memoryview(str(s).encode('ascii')), dtype=np.uint8)
     if copy:
         array = array.copy()
     return array

--- a/dnaset/util.py
+++ b/dnaset/util.py
@@ -11,9 +11,10 @@ def seq_to_array(s, copy=True):
     return array
 
 def seq_to_torch(s, copy=True):
-    array = torch.Tensor(memoryview(str(s).encode('ascii')), dtype=torch.uint8)
+    array = torch.Tensor(memoryview(str(s).encode('ascii'))) #I'm not entirely clear on what memoryview is used for
+    array = array.type(torch.uint8)
     if copy:
-        array = array.copy()
+        array = torch.clone(array)
     return array
 
 
@@ -76,6 +77,36 @@ def bed_to_sequence_generator(
             'stop': stop,
             'sequence': sequence,
         }
+
+'''
+def bed_to_bbed(pth, out_pth, n_chroms = None):
+
+    Converts a bed file into a compressed format that allows for random line access
+
+    args:
+        pth - location of bed file
+        n_chroms - number of chromosomes expected in the BED file. Will throw an error
+            if unique chromosomes exceeds this number
+
+    if n_chroms is not None:
+        chroms = [None for _ in range(n_chroms)]
+    else:
+        chroms = []
+    i = 0
+    with open(pth) as ifp, open(out_pth,'wb') as ofp:
+        for line in ifp:
+            chrom = line.split('\t')[0]
+            if chrom not in chroms:
+                if n_chroms is None:
+                    chroms.append(chrom)
+                else:
+                    try:
+                        chroms[i]=chrom
+                    except(IndexError):
+                        raise AssertionError(f"Number of unique chroms exceeds expected value ({n_chroms})\nChromosomes identified: {chroms}")
+
+    
+'''
 
 
 

--- a/dnaset/util.py
+++ b/dnaset/util.py
@@ -11,7 +11,7 @@ def seq_to_array(s, copy=True):
     return array
 
 def seq_to_torch(s, copy=True):
-    array = torch.Tensor(memoryview(str(s).encode('ascii')), dtype=np.uint8)
+    array = torch.Tensor(memoryview(str(s).encode('ascii')), dtype=torch.uint8)
     if copy:
         array = array.copy()
     return array


### PR DESCRIPTION
Created new class RBedTool that is nothing more than a simple CSV parser. It can access data sequentially in O(1) time and randomly in O(n) time.

Added two context managers to allow index/parse errors generated by RBedTools and BigwigDataset generators to be suppressed to print statements.

Created more verbose error messages so it's clear when there is an error thrown, what chromosome/bed file line caused the issue.

Also added new optional parameter to BigwigDataset, out_type to allow the output to be returned as either a dict or a tuple.